### PR TITLE
Fix prefix

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,4 +1,4 @@
-define: prefix docs/languages/scala/driver
+define: prefix docs/languages/scala/scala-driver
 define: base https://www.mongodb.com/${prefix}
 define: versions master
 


### PR DESCRIPTION
# Pull Request Info

The prefix has changed since the repo was set up. This corrects that. All database corrections have been made. These redirects need to match that.

Reference to the [URL Mapping in the PD](https://docs.google.com/document/d/13ysyOHNy-oYsPQoYxg5ZmxOXR4_7TPF0zAZs9JSIOpI/edit).
