### PR TITLE
DOCSP-35842: Add Scala Maven repository link to to installation page

### DIFF
--- a/source/installation.txt
+++ b/source/installation.txt
@@ -12,7 +12,9 @@ Installation
    :keywords: dependency, reactive streams, add package, sbt, maven
 
 The recommended way to get started with the {+driver-short+} in your
-project is by using a dependency management system.
+project is by using a dependency management system. If you would like to manually
+download our Scala drivers, you can do so through the `Scala driver Maven repository
+<https://mvnrepository.com/artifact/org.mongodb.scala/mongo-scala-driver>`__.
 
 The following sections contain the Reactive Streams-based Scala
 implementation for asynchronous stream processing with non-blocking back

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -12,8 +12,8 @@ Installation
    :keywords: dependency, reactive streams, add package, sbt, maven
 
 The recommended way to get started with the {+driver-short+} in your
-project is by using a dependency management system. If you would like to manually
-download our Scala drivers, you can do so through the `Scala driver Maven repository
+project is by using a dependency management system. To manually
+download the MongoDB Scala driver, see the `Scala driver Maven repository
 <https://mvnrepository.com/artifact/org.mongodb.scala/mongo-scala-driver>`__.
 
 The following sections contain the Reactive Streams-based Scala


### PR DESCRIPTION
# Pull Request Info

Updating Scala installation page by adding direct link to Mongo Scala Driver .jar files on Maven repository.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-scala/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35842>
Staging - <https://preview-mongodbmcmorisi.gatsbyjs.io/scala/DOCSP-35842-maven-link/installation/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
