### PR TITLE
DOCSP-48722: Update MongoDB credential placeholder

### DIFF
--- a/source/includes/security/auth.scala
+++ b/source/includes/security/auth.scala
@@ -8,7 +8,7 @@ object StableAPI {
 
     {
       // start-default
-      val user = "<username>"     // the username
+      val user = "<db_username>"     // the username
       val source = "<source>"     // the source where the user is defined
       val password = ...          // the password as a character array
 

--- a/source/includes/security/auth.scala
+++ b/source/includes/security/auth.scala
@@ -30,7 +30,7 @@ object StableAPI {
 
     {
       // start-scram-sha-256
-      val user = "<username>"     // the username
+      val user = "<db_username>"     // the username
       val source = "<source>"     // the source where the user is defined
       val password = ...          // the password as a character array
 
@@ -52,7 +52,7 @@ object StableAPI {
 
     {
       // start-scram-sha-1
-      val user = "<username>"     // the username
+      val user = "<db_username>"     // the username
       val source = "<source>"     // the source where the user is defined
       val password = ...          // the password as a character array
 


### PR DESCRIPTION
# Pull Request Info
This one I'm actually updating the internal MongoDB credential placeholder to be `db_username` to match Atlas.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-scala/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-48722>
Staging - <https://deploy-preview-120--docs-scala.netlify.app/security/auth/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
