### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -3,7 +3,7 @@
 ====================
 
 .. meta::
-   :description: Explore resources and tutorials for using the MongoDB Scala Driver, including installation, connection setup, data operations, and more.
+   :description: Explore resources and tutorials for using the MongoDB Scala Driver.
 
 .. contents:: On this page
    :local:

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 {+driver-long+}
 ====================
 
+.. meta::
+   :description: Explore resources and tutorials for using the MongoDB Scala Driver, including installation, connection setup, data operations, and more.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -10,7 +10,7 @@ What's New
 
 .. meta::
    :keywords: update, new feature, deprecation, upgrade
-   :description: Discover new features, improvements, and fixes in recent versions of the MongoDB Scala Driver, including updates on vector storage, authentication, and performance enhancements.
+   :description: Discover new features, improvements, and fixes in each version of the MongoDB Scala Driver.
 
 .. contents:: On this page
    :local:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -10,6 +10,7 @@ What's New
 
 .. meta::
    :keywords: update, new feature, deprecation, upgrade
+   :description: Discover new features, improvements, and fixes in recent versions of the MongoDB Scala Driver, including updates on vector storage, authentication, and performance enhancements.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539